### PR TITLE
Github Actions and Script Compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+venv
 *.zip
 *.dll
 temp/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # higurashi_release
 
+This repository contains scripts used for deploying the 07th-mod Higurashi mods.
+
+## higurashi_release.py
+
 This simple script creates Higurashi releases from [07th-Mod](https://github.com/07th-mod/) with close to no human interaction.
 It will fetch all the latest files from the game repository and 07th-Mod server to create a zip file that can be extracted directly into the game folder or uploaded as a new release.
 
@@ -27,3 +31,21 @@ Example: ``python higurashi_release.py meakashi``
   - unlikely but feel free to fork and diy
 - ~~Batch support~~
   - You might want to try ``for %x in (onikakushi watanagashi tatarigoroshi himatsubushi meakashi tsumihoroboshi minagoroshi matsuribayashi) do py higurashi_make.py %x`` in Windows (or the equivalent in Linux)
+
+## compile_higurashi_scripts
+
+### compile_higurashi_scripts.py
+
+This script compiles scripts for each game. It is called by the Github Actions script in each higurashi repository which automatically raises a pull request with the compiled scripts, and is not intended to be called directly from the command line. It should be called from the root of a higurashi mod github repo, as it will expect a folder called `Update` containing the scripts to be compiled.
+
+## Prerequisites
+
+The example github workflow file already has the prerequisites setup, but if you are running this manually you will need:
+
+- Python 3.8 or higher
+- Curl
+- 7zip (script only works with `7z` at the moment, not `7za`)
+
+### pr_workflow_example.yml
+
+This is an example Github Actions workflow which downloads and calls the `compile_higurashi_scripts.py`, then creates a new pull request with the compiled scripts.

--- a/compile_higurashi_scripts/compile_higurashi_scripts.py
+++ b/compile_higurashi_scripts/compile_higurashi_scripts.py
@@ -1,0 +1,158 @@
+import os
+import shutil
+import subprocess
+import sys
+from sys import argv, stdout
+
+
+def isWindows():
+    return sys.platform == "win32"
+
+
+def call(args, **kwargs):
+    print("running: {}".format(args))
+    retcode = subprocess.call(args, shell=isWindows(), **kwargs)  # use shell on windows
+    if retcode != 0:
+        raise SystemExit(retcode)
+
+
+def tryRemoveTree(path):
+    try:
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def sevenZipMakeArchive(input_path, output_filename):
+    tryRemoveTree(output_filename)
+    call(["7z", "a", output_filename, input_path])
+
+
+def sevenZipExtract(input_path, outputDir=None):
+    args = ["7z", "x", input_path, '-y']
+    if outputDir:
+        args.append('-o' + outputDir)
+
+    call(args)
+
+
+def download(url):
+    print(f"Starting download of URL: {url}")
+    call(['curl', '-OJL', url])
+
+
+class ChapterInfo:
+    def __init__(self, name, episodeNumber, uiFileName):
+        self.name = name
+        self.episodeNumber = episodeNumber
+        self.dataFolderName = f'HigurashiEp{episodeNumber:02}_Data'
+        self.uiArchiveName = uiFileName
+
+
+def compileScripts(chapter: ChapterInfo):
+    """
+    Compiles scripts for the given chapter.
+
+    Expects:
+        - to run on a Windows machine
+        - Windows, Steam UI files
+        - Windows, Steam base assets
+    """
+    baseArchiveName = f'{chapter.name}_base.7z'
+
+    # - Download and extract the base archive for the selected game, using key
+    download(f'https://07th-mod.com/misc/script_building/{baseArchiveName}')
+    # Do not replace the below call with sevenZipExtract() as it would expose the 'EXTRACT_KEY'
+    subprocess.call(["7z", "x", baseArchiveName, '-y', f"-p{os.environ['EXTRACT_KEY']}"], shell=isWindows())
+
+    print(f"\n\n>> Compiling [{chapter.name}] scripts...")
+    baseFolderName = f'{chapter.name}_base'
+
+    # - Download and extract the UI archive for the selected game
+    uiArchiveName = chapter.uiArchiveName
+    download(f'https://07th-mod.com/rikachama/ui/{uiArchiveName}')
+    sevenZipExtract(uiArchiveName, baseFolderName)
+
+    # - Download the DLL for the selected game
+    # TODO: when experimental DLL is released, don't use experimental DLL for building
+    dllArchiveName = f'experimental-drojf-dll-ep{chapter.episodeNumber}.7z'
+    download(f'https://github.com/drojf/higurashi-assembly/releases/latest/download/{dllArchiveName}')
+    sevenZipExtract(dllArchiveName, baseFolderName)
+
+    # - Copy the Update folder containing the scripts to be compiled to the base folder, so the game can find it
+    shutil.copytree(f'Update', f'{baseFolderName}/{chapter.dataFolderName}/StreamingAssets/Update', dirs_exist_ok=True)
+
+    # - Remove status file if it exists
+    statusFilename = "higu_script_compile_status.txt"
+    if os.path.exists(statusFilename):
+        os.remove(statusFilename)
+
+    # - Run the game with 'quitaftercompile' as argument
+    call([f'{baseFolderName}\\HigurashiEp{chapter.episodeNumber:02}.exe', 'quitaftercompile'])
+
+    # - Check compile status file
+    if not os.path.exists(statusFilename):
+        raise SystemExit("Script Compile Failed: Script compilation status file not found")
+
+    with open(statusFilename, "r") as f:
+        status = f.read().strip()
+        if status != "Compile OK":
+            raise SystemExit(f"Script Compile Failed: Script compilation status indicated status {status}")
+
+    os.remove(statusFilename)
+
+    # - Copy the CompiledScriptsUpdate folder to the expected final build dir
+    shutil.copytree(f'{baseFolderName}/{chapter.dataFolderName}/StreamingAssets/CompiledUpdateScripts', f'CompiledUpdateScripts', dirs_exist_ok=True)
+
+    # Clean up
+    os.remove(uiArchiveName)
+    os.remove(dllArchiveName)
+    shutil.rmtree(baseFolderName)
+
+    # Clean up base archive
+    os.remove(baseArchiveName)
+
+
+def main():
+    if sys.version_info < (3, 8):
+        raise SystemExit(f"""ERROR: This script requires Python >= 3.8 to run (you have {sys.version_info.major}.{sys.version_info.minor})!
+
+This script uses 3.8's 'dirs_exist_ok=True' argument for shutil.copy.""")
+
+    help = """Usage:
+            compile_higurashi_scripts.py (onikakushi | watanagashi | tatarigoroshi | himatsubushi | meakashi | tsumihoroboshi | minagoroshi | matsuribayashi)
+           """
+
+    # Enables the chapter name as an argument. Example: Himatsubushi
+    if len(argv) < 2:
+        raise SystemExit(help)
+
+    chapterName = argv[1]
+
+    chapterListA = [
+        ChapterInfo("onikakushi",       1, "Onikakushi-UI_5.2.2f1_win.7z"),
+        ChapterInfo("watanagashi",      2, "Watanagashi-UI_5.2.2f1_win.7z"),
+        ChapterInfo("tatarigoroshi",    3, "Tatarigoroshi-UI_5.4.0f1_win.7z"),
+        ChapterInfo("himatsubushi",     4, "Himatsubushi-UI_5.4.1f1_win.7z"),
+        ChapterInfo("meakashi",         5, "Meakashi-UI_5.5.3p3_win.7z"),
+        ChapterInfo("tsumihoroboshi",   6, "Tsumihoroboshi-UI_5.5.3p3_win.7z"),
+        ChapterInfo("minagoroshi",      7, "Minagoroshi-UI_5.6.7f1_win.7z"),
+        ChapterInfo("matsuribayashi",   8, "Matsuribayashi-UI_2017.2.5_win.7z")
+    ]
+
+    chapterDict = dict((chapter.name, chapter) for chapter in chapterListA)
+
+    if chapterName not in chapterDict:
+        raise SystemExit(f"Error: Invalid Chapter [{chapterName}]\n\n{help}")
+
+    chapter = chapterDict[chapterName]
+
+    # Compile every chapter's scripts before building archives
+    compileScripts(chapter)
+
+
+if __name__ == "__main__":
+    main()

--- a/compile_higurashi_scripts/pr_workflow_example.yml
+++ b/compile_higurashi_scripts/pr_workflow_example.yml
@@ -1,0 +1,48 @@
+name: Generate Compiled Scripts Pull Request
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  windows_build:
+    name: Windows Build
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      # Setup python (Windows VM is Python 3.7 by default, we need at least Python 3.8)
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # NOTE: I use ${{ github.event.repository.name }} so the script knows what game is being compiled, but not
+      #       sure if this works in all cases, see:
+      #       https://stackoverflow.com/questions/62803531/repository-name-as-a-github-action-environment-variable
+      #       may need to use ${{ github.event.pull_request.base.repo.name }} for pull requests?
+      - name: Run Release Script
+        env:
+          EXTRACT_KEY: ${{ secrets.EXTRACT_KEY }}
+        run: |
+          curl -OJ https://raw.githubusercontent.com/07th-mod/higurashi_release/master/compile_higurashi_scripts/compile_higurashi_scripts.py
+          python compile_higurashi_scripts.py ${{ github.event.repository.name }}
+          rm compile_higurashi_scripts.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: update compiled scripts
+          title: Update compiled scripts
+          body: |
+            This is an automatically generated pull request.
+
+            This pull request compiles all the scripts in the `Update` folder into the `CompiledUpdateScripts` folder,
+            so the end-user does not need to compile it on their end.
+          branch: update-compiled-scripts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+colorama
+requests


### PR DESCRIPTION
I got the script compilation working in my fork of your repo. It uses Github Actions to compile scripts and package all chapters (except console), resulting in a release like this: https://github.com/drojf/higurashi_release/releases/tag/v0.0.5 . I can change it to compile only one chapter at a time etc, but just did it this way for now (it doesn't take that long). 

Note that there may be some issues when running it manually on your computer, if some temp files aren't deleted or you cancel the script half way (it will fail to overwrite certain files). On a VM it doesn't matter as everything gets cleared each run.

I realized while I was doing it that I wasn't sure on which repository / when this script should be run. Also, I notice you labeled the releases as X.Y.Z so that you could manually enter the release number. We could integrate it with each repository and copy the release tag into the release name, but since we don't do releases that often, may not be worth it.

So uh, let me know how this part should work:
 - Should we leave it in the higurashi_release repo, manually running the release when necessary? Then it's up to you to copy out the .zip files and rename them etc. You can create a dummy tag each time you want to do a release to force a re-buiild. (this is the least effort option)
 - Should we integrate this script into each higurashi repository, to automatically generate a release on tag?
 - Some other way of running it?
